### PR TITLE
Remove display:block from images

### DIFF
--- a/index.css
+++ b/index.css
@@ -165,7 +165,6 @@
  */
 .stackgl-readme img {
   max-width: 100%;
-  display: block;
 }
 .stackgl-readme a img {
   /*border-bottom: 1px solid #f00;*/


### PR DESCRIPTION
See: #2. Not sure if this is acceptable for stackgl css or if there's another way to override this. It's inserted dynamically as a script tag, so need to think about how to properly override this in case this change isn't acceptable (or just if there are other changes that would be nice but that might not apply to stackgl)
